### PR TITLE
Quick patch for quiet.css

### DIFF
--- a/css/discord-reborn.css
+++ b/css/discord-reborn.css
@@ -81,13 +81,14 @@
   /* color for streaming status */
 }
 
+
 .theme-dark .chat form {
     -webkit-box-shadow: 0 -1px 0 hsla(0,0%,100%,.06);
-    background-color: rgba(0,0,0,0.6) !important;
+    background-color: rgba(0,0,0,0.4) !important;
 }
 
 .guilds-wrapper {
-    background-color: rgba(0,0,0,0.6) !important;
+    background-color: rgba(0,0,0,0.8) !important;
 }
 
 .callout-backdrop, .appMount-14L89u {
@@ -117,4 +118,98 @@
 
 .menu-3BZuDT.alt-2vq4VR, .listeningAlong-13-Udx {
     background: var(--primary-color) !important;
+}
+
+.private-channels .search-bar .search-bar-inner {
+  background: transparent;
+}
+
+.search .search-bar, .search .search-bar-icon {
+  background-color: transparent !important;
+}
+
+.channel-members-wrap, .guilds-wrapper, .channels-wrap .flexChild-1KGW5q, .container-iksrDt, .container-3lnMWU, #friends .friends-header, .chat .title-wrap, .popout.popout-bottom-right.no-arrow.no-shadow, .chat form .channel-text-area-default, .search-results-wrap, .embed-2diOCQ, .emojiPicker-3g68GS, .channels-3g2vYe .scrollerWrap-2uBjct, .channels-3g2vYe .flexChild-1KGW5q, .wrapper-uAa07y, .cardPrimary-ZVL9Jr, .cardPrimaryEditable-2IQ7-V, .authedApp-2JX_oI, .modal-3HOjGZ .message-25xg43, .theme-dark .autocomplete-1TnWNR, .menu-3BZuDT {
+  box-shadow: 0 0px 0px rgba(0,0,0,0) !important;
+}
+
+.chat .flex-lFgbSz.flex-3B1Tl4.horizontal-2BEEBe.horizontal-2VE-Fw.flex-3B1Tl4.directionRow-yNbSvJ.justifyStart-2yIZo0.alignStretch-1hwxMa.noWrap-v6g9vO,
+.chat .flex-lFgbSz.flex-3B1Tl4.horizontal-2BEEBe.horizontal-2VE-Fw.flex-3B1Tl4.directionRow-yNbSvJ.justifyStart-2yIZo0.alignStretch-1hwxMa.noWrap-v6g9vO:hover {
+  background-color: transparent !important;
+  transition: background-color .2s linear;
+}
+
+.friends-table .scroller-wrap ::-webkit-scrollbar-track-piece, .messages-wrapper .scroller-wrap ::-webkit-scrollbar-track-piece {
+  background-color: transparent !important;
+  border-color: transparent !important;
+}
+
+.friends-table .scroller-wrap ::-webkit-scrollbar-thumb, .messages-wrapper .scroller-wrap ::-webkit-scrollbar-thumb {
+  background-color: transparent !important;
+  border-color: transparent !important;
+}
+
+.theme-dark .member-2FrNV0:hover .content-3JzEqq {
+  background-color: rgba(0,0,0,0.4);
+  color: #fff;
+}
+
+.channels-3g2vYe .scroller-fzNley>[class*=container-]>[class*=container]:first-of-type>[class*=wrapper] {
+  margin-left: 0px;
+  height: 31.11px;
+  padding: 0 8px;
+  border-radius: 0px;
+  background-color: transparent !important;
+}
+
+.contentSelectedText-3j5CXt {
+  background-color: rgba(0,0,0,0.4);
+  border-left: 0px;
+}
+
+.contentHoveredText-2HYGIY, .contentHoveredVoice-3qGNKh:active, .contentSelectedVoice-gTtYM9:active {
+  background-color: rgba(0,0,0,0.4);
+  border-left: 0px;
+}
+
+.citar-btn {
+  background-color: var(--rs-transparency);
+}
+
+/* Better Formatting Redux Re-Skin */
+
+form .bf-toolbar{transform: translate(-3px,-45px) !important;}
+.bf-toolbar .bf-arrow{right:1px !important;top:16px !important;background-color:var(--rs-transparency) !important;opacity:.5 !important;border-left:0px !important;border-right:0px !important;border-top:0px !important;z-index:1 !important;}
+.bf-toolbar.bf-visible .bf-arrow, .bf-toolbar.bf-hover:hover .bf-arrow{-webkit-transform:translate(12.5px,-3.5px)rotate(-90deg) !important;-ms-transform:translate(13px,-5px)rotate(-90deg) !important;background-color:var(--rs-transparency)!important;transform:translate(13px,-5px)rotate(-90deg !important);width:46px !important;height:23px !important;opacity:.5 !important;border-top:0px solid #212121 !important;border-right:0px solid #212121 !important;border-bottom:0px solid #212121 !important;border-left:0px solid #19191b!important;z-index:0 !important;}
+.bf-toolbar:before{content:"";width:93% !important;background:var(--rs-transparency) !important;box-shadow:0px 0px 0px 0px var(--rs-transparency) !important;border:0px solid var(--rs-transparency) !important;border-right:0px solid var(--rs-transparency) !important;left:6px !important;border-radius: 0px;height:40px;}
+.bf-toolbar div:not(.bf-arrow):hover{background: var(--rs-transparency) !important;color:#fff !important;}
+.bd-detached-css-editor #bd-customcss-attach-controls button:active,.ui-standard-sidebar-view #bd-customcss-attach-controls button:active,.ui-standard-sidebar-view #editor-detached button:active{background:var(--hover-color) !important;}
+.bf-toolbar div:not(.bf-arrow){margin-top:-2px;}
+.bf-toolbar.bf-visible div:not(.bf-arrow), .bf-toolbar.bf-hover:hover div:not(.bf-arrow){z-index:2;}
+.bf-toolbar.bf-visible:before, .bf-toolbar.bf-hover:hover:before{-webkit-transform:translate(0,-4px)!important;-ms-transform:translate(0,-4px)!important;transform:translate(0,-4px) !important;z-index:1;}
+.upload-modal .bf-toolbar {background: var(--rs-transparency) !important;}
+.theme-dark .upload-modal .inner-3if5cm {background-color: var(--tertiary-color) !important;}
+.bf-toolbar.bf-visible div:not(.bf-arrow), .bf-toolbar.bf-hover:hover div:not(.bf-arrow){z-index:2;}
+.bf-toolbar.bf-visible:before, .bf-toolbar.bf-hover:hover:before{-webkit-transform:translate(0,-4px)!important;-ms-transform:translate(0,-4px)!important;transform:translate(0,-4px) !important;z-index:1;}
+.upload-modal .bf-toolbar {background: var(--rs-transparency) !important;}
+.theme-dark .upload-modal .inner-3if5cm {background-color: var(--tertiary-color) !important;}
+
+.theme-dark .cardPrimary-ZVL9Jr {
+  background: var(--quaternary-color) !important;
+}
+
+.theme-dark .card-11ynQk:before {
+  background-color: rgba(0,0,0,0.4);
+  border-color: rgba(0,0,0,0.8);
+}
+
+.theme-dark #friends .friends-table .friends-row:hover {
+  background: rgba(0,0,0,0.4);
+}
+
+.friends-table{
+  margin-top: 0 !important;
+}
+
+.guilds-wrapper .guild.guilds-add::after {
+  background: rgba(0,0,0,0.4);
 }

--- a/css/quiet.css
+++ b/css/quiet.css
@@ -351,6 +351,18 @@ pre {
   border-left: 2px solid var(--hover-color);
 }
 
+.theme-dark .private-channel-recipients-invite .friend.selected, .theme-dark .private-channel-recipients-invite .friend {
+	background: var(--secondary-color) !important;
+}
+
+.theme-dark .private-channel-recipients-invite .friend:hover {
+	background: var(--primary-color) !important;
+}
+
+.theme-dark .themed-popout .footer {
+	background: var(--tertiary-color) !important;
+}
+
 /* 6. Channel List Area */
 
 .theme-light .icon-2WU8ha, .theme-light path[d*="M11.5,9 C13.1575,9 14.5,7.6575 14.5,6 C14.5,4.3425 13.1575,3 11.5,3 C9.8425,3 8.5,4.3425 8.5,6 C8.5,7.6575 9.8425,9 11.5,9 Z M4,7 L4,5 L3,5 L3,7 L1,7 L1,8 L3,8 L3,10 L4,10 L4,8 L6,8 L6,7 L4,7 Z M11.5,10 C9.4975,10 6,11.005 6,13 L6,15 L17,15 L17,13 C17,11.005 13.5025,10 11.5,10 Z"] {
@@ -1019,23 +1031,6 @@ pre {
 
 .avatar-small, .avatar-large { border-radius: 1px !important;}
 
-.avatar-small .status { 
-  height: 100%; 
-  width: 100%; 
-  top: -2px !important; 
-  left: -2px !important; 
-  border: 2px solid !important; 
-  background: transparent !important; 
-  border-radius: 1px !important;
-}
-
-.status.status-online{ border-color: var(--rs-online-color) !important}
-.status.status-idle { border-color: var(--rs-idle-color) !important}
-.status.status-dnd { border-color: var(--rs-dnd-color) !important}
-.status.status-invisible { border-color: var(--rs-invisible-color) !important}
-.status.status-streaming { border-color: var(--rs-streaming-color) !important}
-.status.status-offline { border-color: var(--rs-offline-color) !important}
-
 .member-2FrNV0 [class*="status-"] { transition: all ease .05s }
 
 .member-2FrNV0 [class*="status-"].statusTyping-lRly31 { border-radius: 20% !important; background: rgba(10,10,10,0.50) !important }
@@ -1047,9 +1042,11 @@ pre {
 }
 
 /* -- just selecting "class*="status-"] ends up giving the voice connection status a border too -- */
+.avatar-small [class*="status-"],
 .member-2FrNV0 [class*="status-"], 
 .userPopout-11hFKo [class*="status-"], 
-.modal-2LIEKY [class*="status-"] {
+.modal-2LIEKY [class*="status-"]
+{
     height: 100% !important;
     width: 100% !important;
     border-radius: 0% !important;
@@ -1061,39 +1058,51 @@ pre {
     transition-duration: .5s !important;
 }
 
+.avatar-small [class*="online"],
 .member-2FrNV0 [class*="status-"].statusOnline-1Mp2_H,
 .userPopout-11hFKo [class*="status-"].statusOnline-1Mp2_H,
-.modal-2LIEKY [class*="status-"].statusOnline-1Mp2_H {
+.modal-2LIEKY [class*="status-"].statusOnline-1Mp2_H
+{
     border-color: var(--rs-online-color) !important;
 }
 
+.avatar-small [class*="idle"],
 .member-2FrNV0 [class*="status-"].statusIdle-2AQdvu,
 .userPopout-11hFKo [class*="status-"].statusIdle-2AQdvu,
-.modal-2LIEKY [class*="status-"].statusIdle-2AQdvu {
+.modal-2LIEKY [class*="status-"].statusIdle-2AQdvu
+{
     border-color: var(--rs-idle-color) !important;
 }
 
+.avatar-small [class*="dnd"],
 .member-2FrNV0 [class*="status-"].statusDnd-35xAXU,
 .userPopout-11hFKo [class*="status-"].statusDnd-35xAXU,
-.modal-2LIEKY [class*="status-"].statusDnd-35xAXU {
+.modal-2LIEKY [class*="status-"].statusDnd-35xAXU
+{
     border-color: var(--rs-dnd-color) !important;
 }
 
+.avatar-small [class*="streaming"],
 .member-2FrNV0 [class*="status-"].statusStreaming-1bZ3Hq,
 .userPopout-11hFKo [class*="status-"].statusStreaming-1bZ3Hq,
-.modal-2LIEKY [class*="status-"].statusStreaming-1bZ3Hq {
+.modal-2LIEKY [class*="status-"].statusStreaming-1bZ3Hq
+{
     border-color: var(--rs-streaming-color) !important;
 }
 
+.avatar-small [class*="offline"],
 .member-2FrNV0 [class*="status-"].statusOffline-jZXr_u,
 .userPopout-11hFKo [class*="status-"].statusOffline-jZXr_u,
-.modal-2LIEKY [class*="status-"].statusOffline-jZXr_u {
+.modal-2LIEKY [class*="status-"].statusOffline-jZXr_u
+{
     border-color: var(--rs-offline-color) !important;
 }
 
+.avatar-small [class*="invisible"],
 .member-2FrNV0 [class*="status-"].statusInvisible-2ci18Q,
 .userPopout-11hFKo [class*="status-"].statusInvisible-2ci18Q,
-.modal-2LIEKY [class*="status-"].statusInvisible-2ci18Q {
+.modal-2LIEKY [class*="status-"].statusInvisible-2ci18Q
+{
     border-color: var(--rs-invisible-color) !important;
 }
 
@@ -1426,6 +1435,15 @@ pre {
 
 .message-group .edit-message .edit-operation>a {
   color: var(--main-color) !important;
+}
+
+.message-group-blocked {
+background: var(--primary-color) !important;
+border-color: var(--tertiary-color);
+}
+
+.message-group-blocked-btn{
+background: var(--tertiary-color) !important;
 }
 
 .message-group .comment .markup .mention {
@@ -2424,6 +2442,10 @@ form.modal-content.form.need-help-modal::after {
 }
 
 /* 25. Server Settings Pop out */
+
+.searchBar-YMJBu9 {
+    background: var(--tertiary-color) !important;
+}
 
 .guild-header.popout-open~.ui-scroller-wrap {
   -ms-transform: translate(0, 40px);

--- a/css/quiet.css
+++ b/css/quiet.css
@@ -1607,6 +1607,13 @@ pre {
   margin-top: 55px !important;
 }
 
+.theme-dark .message-group.is-local-bot-message {
+  background-image: var(--primary-color);
+  padding-left: 20px !important;
+  margin-left: 0px !important;
+  width: 100% !important;
+}
+
 /* 14. Friends List */
 
 .theme-dark #friends .friends-table .friends-row:hover {

--- a/css/quiet.css
+++ b/css/quiet.css
@@ -4,7 +4,7 @@
 /* User Settings */
 :root {
 	--theme-name: "Quiet";
-	--theme-version: "1.4";
+	--theme-version: "1.3.1";
 }
 
 /* Dark Mode Settings */
@@ -215,7 +215,7 @@ pre {
 }
 
 .search .search-bar {
-  background-color: var(--quaternary-color) !important;
+  background-color: var(--quaternary-color);
   height: 46px;
   width: 170px;
   border-radius: 0px;
@@ -267,7 +267,7 @@ pre {
 
 .popout .themed-popout .header {
   border-radius: 0px;
-  background-color: var(--quaternary-color) !important;
+  background-color: var(--quaternary-color);
 }
 
 .messages-popout-wrap .messages-popout .message-group {
@@ -752,6 +752,10 @@ pre {
   height: 18px;
   line-height: 18px;
 }
+
+.channel-members-wrap, .guilds-wrapper, .channels-wrap .flexChild-1KGW5q, .container-iksrDt, .container-3lnMWU, #friends .friends-header, .chat .title-wrap, .popout.popout-bottom-right.no-arrow.no-shadow, .chat form .channel-text-area-default, .search-results-wrap, .embed-2diOCQ, .emojiPicker-3g68GS, .channels-3g2vYe .scrollerWrap-2uBjct, .channels-3g2vYe .flexChild-1KGW5q, .wrapper-uAa07y, .cardPrimary-ZVL9Jr, .cardPrimaryEditable-2IQ7-V, .authedApp-2JX_oI, .modal-3HOjGZ .message-25xg43, .theme-dark .autocomplete-1TnWNR, .menu-3BZuDT {
+  box-shadow: 0 0px 0px rgba(0,0,0,0.0) !important;
+}
 /* 9. Emoji Picker */
 
 .popout.no-shadow .emojiPicker-3g68GS, .popout.no-shadow #bda-qem-favourite-container, .popout.no-shadow #bda-qem-twitch-container {
@@ -1081,6 +1085,14 @@ pre {
 }
 /* 11. Popout Menu -> User Status */
 
+.headerPlaying-2Q7mBy {
+  background: var(--secondary-color);
+}
+
+.topSectionPlaying-3jAH9b {
+  background: var(--secondary-color);
+}
+
 .popout.popout-top, .popout.popout-top-left {
   overflow: visible !important;
 }
@@ -1235,6 +1247,11 @@ pre {
 
 /* 12. Members List Area */
 
+.theme-dark .member-2FrNV0:hover .content-3JzEqq {
+  background-color: var(--quaternary-color) !important;
+  color: #fff;
+}
+
 .message-group .mentioned .message-text:after {
   display: none !important;
 }
@@ -1247,11 +1264,6 @@ pre {
 
 /* -- MORE CLASS NAME CHANGES -- */
 
-#app-mount .status.status-typing .spinner-item {
-  height: 3px;
-  width: 3px;
-  border-radius: 0px !important;
-}
 
 .member-2FrNV0 [class*="status-"].statusTyping-lRly31 .pulsingEllipsisItem-1oPdBE {
   height: 3px;
@@ -1562,6 +1574,11 @@ pre {
 
 /* 14. Friends List */
 
+.theme-dark #friends .friends-table .friends-row:hover {
+  background: var(--quaternary-color) !important;
+  border-color: transparent;
+}
+
 #friends, .friends-table {
   background-color: var(--primary-color) !important;
 }
@@ -1647,6 +1664,15 @@ pre {
 }
 
 /* 16. Channel Search Pop out */
+
+.theme-dark .search .search-bar {
+  background-color: var(--primary-color);
+}
+
+.search .search-bar-icon {
+  width: 35px;
+  background-color: var(--primary-color) !important;
+}
 
 .search-popout {
   background-color: var(--primary-color) !important;

--- a/css/quiet.css
+++ b/css/quiet.css
@@ -1291,14 +1291,13 @@ pre {
 	font-size:15px;
 }
 
-.theme-dark .channel-members .member-2FrNV0.popout-open, .theme-dark .channel-members .member-2FrNV0:active, .theme-dark .channel-members .member-2FrNV0:hover.popout-open, .theme-dark .channel-members .member-2FrNV0:hover.popout-open:active {
-  background: var(--quaternary-color) !important;
-  border-left: 2px solid var(--main-color);
-}
+.theme-dark .channel-members .member-2FrNV0.popout-open, .theme-dark .channel-members .member-2FrNV0:active, .theme-dark .channel-members .member-2FrNV0.popout-open:hover, .theme-dark .channel-members .member-2FrNV0.popout-open:active {
+   background: var(--quaternary-color) !important;
+   border-left: 2px solid var(--main-color);
+ }
 
-.theme-dark .channel-members .member-2FrNV0:hover {
-  background: var(--secondary-color) !important;
-  border-left: 2px solid var(--hover-color);
+.channel-members .member-2FrNV0:hover .content-3JzEqq, .channel-members .member-2FrNV0.popout-open .content-3JzEqq {
+	background: var(--quaternary-color) !important;
 }
 
 .channel-members .member-2FrNV0 .activityText-258pdj {

--- a/css/quiet.css
+++ b/css/quiet.css
@@ -7,16 +7,6 @@
 	--theme-version: "1.3.1";
 }
 
-</style>
-
-<script>
-  $('.content-3JzEqq').mouseenter(()=>{
-    console.log('rawgit test. pls work thank you v much');
-  })
-</script>
-
-<style>
-
 /* Dark Mode Settings */
 
 .app.theme-dark, .theme-dark, .theme-dark .theme-light, .theme-dark.popouts, .theme-light.popouts+.tooltips, .tooltips+.theme-dark {

--- a/css/quiet.css
+++ b/css/quiet.css
@@ -556,7 +556,7 @@ pre {
 }
 
 .guilds-wrapper .guilds .guild.unread:before {
-  transition: all .25 linear;
+  transition: all ease .2s;
 }
 
 .guilds-wrapper .guilds .guild .guild-inner {

--- a/css/quiet.css
+++ b/css/quiet.css
@@ -7,6 +7,16 @@
 	--theme-version: "1.3.1";
 }
 
+</style>
+
+<script>
+  $('.content-3JzEqq').mouseenter(()=>{
+    console.log('rawgit test. pls work thank you v much');
+  })
+</script>
+
+<style>
+
 /* Dark Mode Settings */
 
 .app.theme-dark, .theme-dark, .theme-dark .theme-light, .theme-dark.popouts, .theme-light.popouts+.tooltips, .tooltips+.theme-dark {

--- a/css/quiet.css
+++ b/css/quiet.css
@@ -159,6 +159,18 @@
   background-color: var(--main-color) !important;
 }
 
+.theme-dark .card-11ynQk:before, .side-2nYO0F .item-3879bf:hover { 
+	background-color: var(--secondary-color) !important; 
+	border-color: var(--secondary-color) !important 
+}
+
+.theme-dark .button-1qrA-N { background-color: var(--secondary-color) !important }
+
+.theme-dark .user-settings-games .game-name-input:focus, .theme-dark .user-settings-games .game-name-input:hover { 
+	background-color: var(--tertiary-color) !important 
+}
+
+
 /* 2. Code Blocks */
 
 pre, code {
@@ -1005,6 +1017,29 @@ pre {
 
 /* 10. Avatars */
 
+.avatar-small, .avatar-large { border-radius: 1px !important;}
+
+.avatar-small .status { 
+  height: 100%; 
+  width: 100%; 
+  top: -2px !important; 
+  left: -2px !important; 
+  border: 2px solid !important; 
+  background: transparent !important; 
+  border-radius: 1px !important;
+}
+
+.status.status-online{ border-color: var(--rs-online-color) !important}
+.status.status-idle { border-color: var(--rs-idle-color) !important}
+.status.status-dnd { border-color: var(--rs-dnd-color) !important}
+.status.status-invisible { border-color: var(--rs-invisible-color) !important}
+.status.status-streaming { border-color: var(--rs-streaming-color) !important}
+.status.status-offline { border-color: var(--rs-offline-color) !important}
+
+.member-2FrNV0 [class*="status-"] { transition: all ease .05s }
+
+.member-2FrNV0 [class*="status-"].statusTyping-lRly31 { border-radius: 20% !important; background: rgba(10,10,10,0.50) !important }
+
 .mask-2vyqAW, .image-EVRGPw {
   border-radius: 0% !important;
   -webkit-mask: none;
@@ -1295,7 +1330,7 @@ pre {
   background-color: var(--rs-invisible-color);
 }
 
-.channel-members {
+.channel-members, .theme-dark .members-1bid1J {
   background-color: var(--primary-color) !important;
 }
 
@@ -1316,7 +1351,7 @@ pre {
   font-size: 10px;
 }
 
-.channel-members h2 {
+.channel-members h2, .membersGroup-3_dP5E {
   color: var(--main-color) !important;
   background-image: linear-gradient(90deg, transparent, transparent), linear-gradient(90deg, transparent, var(--main-color), transparent);
   background-size: 100% 3px;
@@ -1334,7 +1369,7 @@ pre {
   margin-left: 15px;
 }
 
-.channel-members h2:first-of-type {
+.channel-members h2:first-of-type, .membersGroup-3_dP5E:first-of-type {
   margin-top: 0px !important;
 }
 
@@ -1936,17 +1971,19 @@ pre {
 
 .need-help-modal .header h1::after {
   content: var(--theme-name)" v" var(--theme-version);
+  white-space: nowrap !important;
   color: #fff;
   font-weight: 700;
   font-size: 250%;
   z-index: 11;
   position: absolute;
   width: 200%;
-  left: 0px;
+  height: 150% !important;
+  left: -220px !important;
   margin-left: -45px;
-  top: 16px;
+  top: 10px !important;
   font-family: Satisfy;
-  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.4);
+  text-shadow: 7px 4px 5px rgba(0, 0, 0, 0.4) !important;
 }
 
 .need-help-modal.deprecated .header {
@@ -1974,7 +2011,7 @@ form.modal-content.form.need-help-modal::after {
   position: relative;
   z-index: 10;
   height: 150px;
-  width: 100%;
+  width: 135% !important;
   padding: 0;
   -webkit-box-pack: center;
   justify-content: center;
@@ -2007,13 +2044,17 @@ form.modal-content.form.need-help-modal::after {
 }
 
 .need-help-modal .form-inner.loading::after {
-  content: "C\0332 r\0332 e\0332 a\0332 t\0332 o\0332 r\0332 :\A Omniscient#0002 \A\A P\0332 e\0332 r\0332 s\0332 o\0332 n\0332 a\0332 l\0332 S\0332 e\0332 r\0332 v\0332 e\0332 r\0332:\A discord.me/mrrobotserver \A\A D\0332 o\0332 n\0332 a\0332 t\0332 i\0332 o\0332 n\0332:\A paypal.me/Chaotiic \A\A C\0332 r\0332 e\0332 d\0332 i\0332 t\0332 s\0332:\A → Dingus#6977 (Helper)";
-  padding: 38px;
-  min-height: 200px;
+  line-height: 15px !important;
+  content: "\A\A\AThanks for purchasing my themes! \A\A\A\A Theme Creators: \A\A\A\A Omniscient#0002 & Kya#0001 \A\A\A\A My Server: \A\A\A\A http://discord.me/mrrobotserver " !important;
+  text-align: center;
+  padding: 58px;
+  min-height: 100px;
+  height: 350px !important;
   background-color: #19191b;
-  width: 100%;
+  width: 140% !important;
   white-space: pre;
   color: #fff;
+  font-size: 150% !important
 }
 
 .need-help-modal .form-inner>ul {
@@ -2035,13 +2076,13 @@ form.modal-content.form.need-help-modal::after {
 }
 
 .need-help-modal .footer::after {
-  content: "\00a0\00a0\00a0\00a0\00a0\00a0\00a0\00a0\00a0Need help? Visit https://betterdocs.net";
+  content: "";
   background-color: #19191b;
-  width: 100%;
+  width: 142% !important;
   height: 34px;
   position: absolute;
   bottom: 0;
-  left: 0;
+  left: -109px !important;
   line-height: 32px;
   border-radius: 0 0 5px 5px;
   border-top: 2px solid #161618;
@@ -2060,6 +2101,11 @@ form.modal-content.form.need-help-modal::after {
   background-image: url(https://storage.googleapis.com/material-icons/external-assets/v4/icons/svg/ic_sentiment_very_dissatisfied_white_24px.svg) !important;
   opacity: 0.3;
 }
+
+.form-deprecated .form-header, .form.deprecated .form-header, .form-deprecated .form-inner, .form.deprecated .form-inner {
+    background-color: var(--main-color) !important;
+}
+
 /* 22. Modals */
 
 .theme-dark .theme-light .clipboardInputInner-oj8y-S {


### PR DESCRIPTION
### Some Bug Fixes since the April Fools update
- Avatar and status border on...:

  1. channel members

  2. user popup 

  3. user modal

- Spinner effect compressed -- it's linked to the status now

- Tried to fix the activity text color based on status **[Heads up: Pretty sure with the current build, it can't be fixed]**

  1. Status identifier *(.statusOnline , .statusIdle, etc.)* is nestled in a different parent class than the activity text so, as far as I know, they can't be fixed

  2. Don't take my full word on it

- Hover color on channel member list fixed

  1. Class names were changed so :hover and :active background color effects weren't working. Simple class name change fixed that.

- Added the corresponding guild-placeholder border-radius to match guild border-radius

  1. Default guild shape is square so placeholder is also defaulting to square